### PR TITLE
fixed the broken anaconda link

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -7,7 +7,7 @@ Getting Python
 ==============
 
 If it's your first time with Python, we recommend
-`Anaconda <https://www.continuum.io/downloads>`_ as an easy-to-use
+`Anaconda <https://www.anaconda.com/>`_ as an easy-to-use
 environment that includes many basic packages. Anaconda is available
 for Windows, Mac OS X and GNU/Linux.
 


### PR DESCRIPTION
apparently the old anaconda link is no longer there, so I changed it to the homepage of anaconda.com

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.